### PR TITLE
Don't request location authorization in init

### DIFF
--- a/ios/RNBoundary.m
+++ b/ios/RNBoundary.m
@@ -11,8 +11,6 @@ RCT_EXPORT_MODULE()
     if (self) {
         self.locationManager = [[CLLocationManager alloc] init];
         self.locationManager.delegate = self;
-
-        [self.locationManager requestAlwaysAuthorization];
     }
 
     return self;


### PR DESCRIPTION
By requesting location authorization in init the permissions dialog will show up on app install which isn't the best user experience. Removing this allows handling permissions on your own terms (perhaps showing a permissions warmer or some other explanation before making the request).