### PR TITLE
(Local) Broadcast the geofence events to the parent module

### DIFF
--- a/android/src/main/java/com/eddieowens/RNBoundaryModule.java
+++ b/android/src/main/java/com/eddieowens/RNBoundaryModule.java
@@ -2,10 +2,14 @@ package com.eddieowens;
 
 import android.Manifest;
 import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import com.eddieowens.receivers.BoundaryEventBroadcastReceiver;
@@ -18,6 +22,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.GeofencingRequest;
@@ -32,9 +37,11 @@ import java.util.List;
 public class RNBoundaryModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
     public static final String TAG = "RNBoundary";
-    private GeofencingClient mGeofencingClient;
+    public static final String GEOFENCE_DATA_TO_EMIT = "com.eddieowens.GEOFENCE_DATA_TO_EMIT";
 
+    private GeofencingClient mGeofencingClient;
     private PendingIntent mBoundaryPendingIntent;
+    private GeofenceDataChangedReceiver geofenceDataChangedReceiver = new GeofenceDataChangedReceiver();
 
     RNBoundaryModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -242,13 +249,40 @@ public class RNBoundaryModule extends ReactContextBaseJavaModule implements Life
         if (mGeofencingClient == null) {
             this.mGeofencingClient = LocationServices.getGeofencingClient(getReactApplicationContext());
         }
+        final IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(GEOFENCE_DATA_TO_EMIT);
+        LocalBroadcastManager
+                .getInstance(this.getReactApplicationContext())
+                .registerReceiver(geofenceDataChangedReceiver, intentFilter);
     }
 
     @Override
     public void onHostPause() {
+        LocalBroadcastManager.getInstance(this.getReactApplicationContext())
+                .unregisterReceiver(geofenceDataChangedReceiver);
     }
 
     @Override
     public void onHostDestroy() {
+    }
+
+
+    private class GeofenceDataChangedReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            final String event = intent.getStringExtra("event");
+            final ArrayList<String> geofenceIds = intent.getStringArrayListExtra("params");
+            final WritableArray geofenceIdsToBridge = Arguments.createArray();
+            for (String geofenceId : geofenceIds) {
+                geofenceIdsToBridge.pushString(geofenceId);
+            }
+
+            Log.i(TAG, "Sending events " + event);
+            RNBoundaryModule.this.getReactApplicationContext()
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(event, geofenceIdsToBridge);
+            Log.i(TAG, "Sent events");
+        }
     }
 }

--- a/android/src/main/java/com/eddieowens/services/BoundaryEventJobIntentService.java
+++ b/android/src/main/java/com/eddieowens/services/BoundaryEventJobIntentService.java
@@ -3,8 +3,10 @@ package com.eddieowens.services;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.v4.app.JobIntentService;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
+import com.eddieowens.RNBoundaryModule;
 import com.eddieowens.errors.GeofenceErrorMessages;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -12,6 +14,9 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.eddieowens.RNBoundaryModule.TAG;
 
@@ -37,28 +42,29 @@ public class BoundaryEventJobIntentService extends JobIntentService {
         switch (geofencingEvent.getGeofenceTransition()) {
             case Geofence.GEOFENCE_TRANSITION_ENTER:
                 Log.i(TAG, "Enter geofence event detected. Sending event.");
-                WritableArray writableArray = Arguments.createArray();
+                final ArrayList<String> enteredGeofences = new ArrayList<>();
                 for (Geofence geofence : geofencingEvent.getTriggeringGeofences()) {
-                    writableArray.pushString(geofence.getRequestId());
+                    enteredGeofences.add(geofence.getRequestId());
                 }
-                sendEvent(ON_ENTER, writableArray);
+                sendEvent(ON_ENTER, enteredGeofences);
                 break;
             case Geofence.GEOFENCE_TRANSITION_EXIT:
                 Log.i(TAG, "Exit geofence event detected. Sending event.");
-                WritableArray writableArray1 = Arguments.createArray();
+                final ArrayList<String> exitingGeofences = new ArrayList<>();
                 for (Geofence geofence : geofencingEvent.getTriggeringGeofences()) {
-                    writableArray1.pushString(geofence.getRequestId());
+                    exitingGeofences.add(geofence.getRequestId());
                 }
-                sendEvent(ON_EXIT, writableArray1);
+                sendEvent(ON_EXIT, exitingGeofences);
                 break;
         }
     }
 
-    private void sendEvent(String event, Object params) {
-        Log.i(TAG, "Sending events " + event);
-        ((ReactApplicationContext) this.getBaseContext())
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(event, params);
-        Log.i(TAG, "Sent events");
+    private void sendEvent(String event, ArrayList<String> params) {
+        final LocalBroadcastManager lbManager =
+                LocalBroadcastManager.getInstance(this.getApplicationContext());
+        final Intent intent = new Intent(RNBoundaryModule.GEOFENCE_DATA_TO_EMIT);
+        intent.putExtra("event", event);
+        intent.putExtra("params", params);
+        lbManager.sendBroadcast(intent);
     }
 }


### PR DESCRIPTION
Hi Eddie,

The approach I mentioned a few days ago appears to work for more modern Android devices. I tested against Android 8.1 with my personal Nexus 5x.

Care to take a look and tell me what you think? I'm a bit wary of the `onHostPause` code since I suspect this means I won't forward events to the React-Native layer unless my app is in the foreground or least, in-memory? However, not unsubscribing a broadcast receiver (Local or otherwise) is a code smell. Would you be able to provide some guidance as to how this should work when the app is not running in the foreground?

Regards,
David