### PR TITLE
Allow Geofence to trigger when app is killed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,11 +4,12 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application>
-        <service
-            android:name=".services.BoundaryEventIntentService"
-            android:enabled="true"
-            android:exported="true"
-            />
+        <receiver
+            android:name=".services.BoundaryEventIntentService">
+            <intent-filter>
+                <action android:name="com.example.geofence.ACTION_RECEIVE" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>
   

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <receiver
             android:name=".services.BoundaryEventIntentService">
             <intent-filter>
-                <action android:name="com.example.geofence.ACTION_RECEIVE" />
+                <action android:name="com.eddieowens.geofence.ACTION_RECEIVE" />
             </intent-filter>
         </receiver>
     </application>

--- a/android/src/main/java/com/eddieowens/services/BoundaryEventIntentService.java
+++ b/android/src/main/java/com/eddieowens/services/BoundaryEventIntentService.java
@@ -1,13 +1,20 @@
 package com.eddieowens.services;
 
 import android.app.IntentService;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.LocalBroadcastManager;
 
+import com.eddieowens.R;
 import com.eddieowens.RNBoundaryModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -17,36 +24,47 @@ import com.google.android.gms.location.GeofencingEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import android.util.Log;
 
 import static com.eddieowens.RNBoundaryModule.ON_ENTER;
 import static com.eddieowens.RNBoundaryModule.ON_EXIT;
 import static com.eddieowens.RNBoundaryModule.TAG;
 
-public class BoundaryEventIntentService extends IntentService {
+public class BoundaryEventIntentService extends BroadcastReceiver {
 
     private static final Logger logger = Logger.getLogger(TAG);
 
     public static final String ACTION = "RNBoundary.Event";
 
-    /**
-     * Creates an IntentService.  Invoked by your subclass's constructor.
-     *
-     * @param name Used to name the worker thread, important only for debugging.
-     */
-    public BoundaryEventIntentService(String name) {
-        super(name);
-    }
-
-    public BoundaryEventIntentService() {
-        super("BoundaryEventIntentService");
-    }
-
     @Override
-    protected void onHandleIntent(@Nullable final Intent intent) {
+    public void onReceive(Context context, Intent intent) {
+      Log.i(TAG, "onReceive");
+        logger.info("Broadcasting event1");
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                int importance = NotificationManager.IMPORTANCE_DEFAULT;
+                NotificationChannel channel = new NotificationChannel("1", "blaname", importance);
+                channel.setDescription("bla");
+                // Register the channel with the system; you can't change the importance
+                // or other notification behaviors after this
+                NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+                notificationManager.createNotificationChannel(channel);
+            }
+
+            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, "1")
+                    .setSmallIcon(R.drawable.common_google_signin_btn_icon_dark)
+                    .setContentTitle("NEw received")
+                    .setContentText("RECEIVED NOT")
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            notificationManager.notify(1, mBuilder.build());
+
+
         if (intent != null) {
+
             logger.info("Broadcasting event");
             intent.setAction(ACTION);
-            LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+            LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import {NativeEventEmitter, NativeModules} from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 
-const {RNBoundary} = NativeModules;
+const { RNBoundary } = NativeModules;
 
 const TAG = "RNBoundary";
 
@@ -39,10 +39,18 @@ export default {
       throw TAG + ': invalid event';
     }
 
+    if (Platform.OS !== 'ios') {
+      RNBoundary.setHasListeners(true);
+    }
+
     return boundaryEventEmitter.addListener(event, callback);
   },
 
   removeAll: () => {
+    if (Platform.OS !== 'ios') {
+      RNBoundary.setHasListeners(false);
+    }
+
     Object.values(Events).forEach(e => boundaryEventEmitter.removeAllListeners(e));
     return RNBoundary.removeAll();
   },
@@ -55,4 +63,3 @@ export default {
     return RNBoundary.remove(id);
   }
 }
-

--- a/ios/RNBoundary.h
+++ b/ios/RNBoundary.h
@@ -11,6 +11,6 @@
 @interface RNBoundary : RCTEventEmitter <RCTBridgeModule, CLLocationManagerDelegate>
 - (bool) removeBoundary:(NSString *)boundaryId;
 - (void) removeAllBoundaries;
+- (void) sendEventAfter:(NSString *)event withBody:(NSString *)body andRetry:(int)retry;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @end
-  


### PR DESCRIPTION
Currently, the geofence does not trigger the Javascript code while the app is killed, as there are no registers set yet.

In iOS, the app will automatically wake-up when the geofence is triggered and the listener will be registered after a few seconds.

In Android, I am instantiating the activity and launching the app, it's quite an ugly solution and I could use headless-js for that.

I haven't merged the latest release, but that gives an idea of how that could be achieved.