### PR TITLE
Implement dealloc method

### DIFF
--- a/ios/RNBoundary.m
+++ b/ios/RNBoundary.m
@@ -16,6 +16,12 @@ RCT_EXPORT_MODULE()
     return self;
 }
 
+- (void)dealloc
+{
+    [self.locationManager stopUpdatingLocation];
+    self.locationManager.delegate = nil;
+}
+
 RCT_EXPORT_METHOD(add:(NSDictionary*)boundary addWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (CLLocationManager.authorizationStatus != kCLAuthorizationStatusAuthorizedAlways) {


### PR DESCRIPTION
XCode were compaining about not being able to dealloc RNBoundary
when reloading JS on device.  Also it is good practice to not leave
memory leeks.