### PR TITLE
Fix #23 - Decouple events and boundaries in .removeAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ class MyComponent extends Class {
   }
   
   componentWillUnmount() {
+    // Remove the events
+    Boundary.off(Events.ENTER)
+    Boundary.off(Events.EXIT)
+
+    // Remove the boundary from native API´s
     Boundary.remove('Chipotle')
       .then(() => console.log('Goodbye Chipotle :('))
       .catch(e => console.log('Failed to delete Chipotle :)', e))
@@ -99,6 +104,7 @@ Add the following to your `Info.plist`:
 Name        | Arguments                                     | Note
 ----------- | --------------------------------------------- | ---
 `on`        | event: [event](#events), callback: `function` | Triggers the callback when the `event` occurs. The callback will be passed an array of boundary ids as `strings`. Can be called in the background
+`off`       | event: [event](#events)                       | Removes bound event listeners
 `add`       | boundary: [boundary](#boundary)               | Adds a `Boundary` that can be triggered when an [event](#events) occurs
 `remove`    | id: `string`                                  | Removes a Boundary from being triggered. Boundaries will remain until `remove` or `removeAll` is called or the app is uninstalled
 `removeAll` | `void`                                        | Removes all boundaries and event callbacks.

--- a/index.js
+++ b/index.js
@@ -49,8 +49,15 @@ export default {
     return boundaryEventEmitter.addListener(event, callback);
   },
 
+  off: (event) => {
+    if (!Object.values(Events).find(e => e === event)) {
+      throw TAG + ': invalid event';
+    }
+
+    return boundaryEventEmitter.removeAllListeners(event);
+  },
+
   removeAll: () => {
-    Object.values(Events).forEach(e => boundaryEventEmitter.removeAllListeners(e));
     return RNBoundary.removeAll();
   },
 


### PR DESCRIPTION
For increased clarity in API it make sense to be consistent
in naming.  If .remove() only remove boundary without touching event listeners, .removeAll() should do the same thing.  Also with previous approach there were no way to flush all boundaries without also flushing the events. If you work with things such as redux-saga it makes a lot of sense to decouple these things because the events are probably best initialized on app startup whereas boundaries are probably initialized/replaced on any API-response.  Or background via remote notification for that matter.

Since this issue have confused at least 2 people so far I think it make sense to go for this clearer interface where nothing happens behind the scenes even if it means that the implementers are required to add an extra row or two.

Since this introduce API change, we should probably bump version to 1.1 and also include a release note about the interface changes.