### PR TITLE
Fix for CocoaPod install on React Native 0.60.x

### DIFF
--- a/ios/RNBoundary.podspec
+++ b/ios/RNBoundary.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNBoundary
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/eddieowens/react-native-boundary"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
When doing pod install was failing due to missing home variable.