### PR TITLE
Fixed podspec to work correctly on React-Native 0.60x

### DIFF
--- a/ios/RNBoundary.podspec
+++ b/ios/RNBoundary.podspec
@@ -1,24 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RNBoundary"
-  s.version      = "1.0.0"
-  s.summary      = "RNBoundary"
-  s.description  = <<-DESC
-                  RNBoundary
-                   DESC
-  s.homepage     = ""
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNBoundary.git", :tag => "master" }
-  s.source_files  = "RNBoundary/**/*.{h,m}"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/eddieowens/react-native-boundary.git", :tag => "#{s.version}" }
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
-
-  s.dependency "React"
-  #s.dependency "others"
-
+  s.dependency 'React'
 end
-
-  


### PR DESCRIPTION
This fix refactors the previous pod spec to use the info from the package.json instead of be hardcoded.
Also fixes pod install so correctly can be auto linked on React-Native 0.60x.