### PR TITLE
Make android and IOS interface consistent

### DIFF
--- a/android/src/main/java/com/eddieowens/RNBoundaryModule.java
+++ b/android/src/main/java/com/eddieowens/RNBoundaryModule.java
@@ -32,9 +32,6 @@ import java.util.List;
 public class RNBoundaryModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
     public static final String TAG = "RNBoundary";
-    public static final String ON_ENTER = "onEnter";
-    public static final String ON_EXIT = "onExit";
-    public static final String GEOFENCE_DATA_TO_EMIT = "com.eddieowens.GEOFENCE_DATA_TO_EMIT";
 
     private GeofencingClient mGeofencingClient;
     private PendingIntent mBoundaryPendingIntent;

--- a/android/src/main/java/com/eddieowens/services/BoundaryEventJobIntentService.java
+++ b/android/src/main/java/com/eddieowens/services/BoundaryEventJobIntentService.java
@@ -38,32 +38,24 @@ public class BoundaryEventJobIntentService extends JobIntentService {
         }
         switch (geofencingEvent.getGeofenceTransition()) {
             case Geofence.GEOFENCE_TRANSITION_ENTER:
-                Log.i(TAG, "Enter geofence event detected. Sending event.");
-                final ArrayList<String> enteredGeofences = new ArrayList<>();
                 for (Geofence geofence : geofencingEvent.getTriggeringGeofences()) {
-                    enteredGeofences.add(geofence.getRequestId());
+                    Log.i(TAG, "Enter geofence event detected. Sending event.");
+                    sendEvent(this.getApplicationContext(), ON_ENTER, geofence.getRequestId());
                 }
-                sendEvent(this.getApplicationContext(), ON_ENTER, enteredGeofences);
                 break;
             case Geofence.GEOFENCE_TRANSITION_EXIT:
-                Log.i(TAG, "Exit geofence event detected. Sending event.");
-                final ArrayList<String> exitingGeofences = new ArrayList<>();
                 for (Geofence geofence : geofencingEvent.getTriggeringGeofences()) {
-                    exitingGeofences.add(geofence.getRequestId());
+                    Log.i(TAG, "Exit geofence event detected. Sending event.");
+                    sendEvent(this.getApplicationContext(), ON_EXIT, geofence.getRequestId());
                 }
-                sendEvent(this.getApplicationContext(), ON_EXIT, exitingGeofences);
                 break;
         }
     }
 
-    private void sendEvent(Context context, String event, ArrayList<String> params) {
-        final Intent intent = new Intent(RNBoundaryModule.GEOFENCE_DATA_TO_EMIT);
-        intent.putExtra("event", event);
-        intent.putExtra("params", params);
-
+    private void sendEvent(Context context, String event, String id) {
         Bundle bundle = new Bundle();
         bundle.putString("event", event);
-        bundle.putStringArrayList("ids", intent.getStringArrayListExtra("params"));
+        bundle.putString("id", id);
 
         Intent headlessBoundaryIntent = new Intent(context, BoundaryEventHeadlessTaskService.class);
         headlessBoundaryIntent.putExtras(bundle);

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ export {
   Events
 }
 
-const HeadlessBoundaryEventTask = async ({event, ids}) => {
-  console.log(event, ids);
-  boundaryEventEmitter.emit(event, ids)
+const HeadlessBoundaryEventTask = async ({event, id}) => {
+  console.log(event, id);
+  boundaryEventEmitter.emit(event, id)
 };
 
 AppRegistry.registerHeadlessTask('OnBoundaryEvent', () => HeadlessBoundaryEventTask);


### PR DESCRIPTION
The previous interface did emit one event per boundary for IOS with
id as a string, whereas the android version did send an array of
strings.